### PR TITLE
3.14 `sys.monitoring` fixes

### DIFF
--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -285,7 +285,10 @@ cpdef _copy_local_sysmon_events(old_code, new_code):
         mon = sys.monitoring
     except AttributeError:  # Python < 3.12
         return new_code
-    for tool_id in range(6):
+    # Tool ids are integers in the range 0 to 5 inclusive.
+    # https://docs.python.org/3/library/sys.monitoring.html#tool-identifiers
+    NUM_TOOLS = 6  
+    for tool_id in range(NUM_TOOLS):
         try:
             events = mon.get_local_events(tool_id, old_code)
             mon.set_local_events(tool_id, new_code, events)

--- a/line_profiler/_line_profiler.pyx
+++ b/line_profiler/_line_profiler.pyx
@@ -393,7 +393,7 @@ cdef class _SysMonitoringState:
         # Set prior state
         # Note: in 3.14.0a1+, calling `sys.monitoring.free_tool_id()`
         # also calls `.clear_tool_id()`, causing existing callbacks and
-        # code-object-local events to be wiped... so don't
+        # code-object-local events to be wiped... so don't call free.
         # this does have the side effect of not overriding the active
         # profiling tool name if one is already in use, but it's
         # probably better this way


### PR DESCRIPTION
Changes
---
- Refactored the calls to `sys.monitoring.free_tool_id()` in `line_profiler/_line_profiler.pyx` because it has gained side effects in Python 3.14
- Added code (and corresponding test) to copy existing code-object-local events over when overwriting the `.__code__` of functions 

Caveats
---
This does result in the active tool at `sys.monitoring.PROFILER_ID` no longer being overwritten with `'line_profiler'` if there is an existing profiling tool. But it doesn't impact how `LineProfiler` functions and it's probably better this way.